### PR TITLE
Moved project version number to 0.1 for publish local purposes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "ExoNode"
 
-version := "1.0"
+version := "0.1"
 
 scalaVersion := "2.12.1"
 


### PR DESCRIPTION
Push down the project version number to so that sbt> publishLocal    will make a 2.12-0.1 artifact ready for Toolkit project to depend on.